### PR TITLE
Update to text labels

### DIFF
--- a/app/Main.qml
+++ b/app/Main.qml
@@ -20,7 +20,7 @@ MainView {
     Page {
         id: mainPage
         header: PageHeader {
-            title: i18n.tr("Bluetooth file transfer....")
+            title: i18n.tr("Bluetooth file transfer")
             leadingActionBar.actions: []
         }
 
@@ -42,13 +42,13 @@ MainView {
 
                     Label {
                         id: label
-                        text: i18n.tr("Your Ubuntu Touch device is now ready to receive files via Bluetooth...")
+                        text: i18n.tr("Your Ubports device is now ready to receive files via Bluetooth…")
                         fontSize: "large"
                         Layout.fillWidth: true
                         wrapMode: Text.WordWrap
                     }
                     Label {
-                        text: i18n.tr("Send a file via Bluetooth to your Ubuntu Touch phone. It will appear in the list below.")
+                        text: i18n.tr("Send a file via Bluetooth to your Ubports device. It will appear in the list below.")
                         fontSize: "x-small"
                         Layout.fillWidth: true
                         wrapMode: Text.WordWrap
@@ -177,9 +177,9 @@ MainView {
                                 text: {
                                     switch (status) {
                                     case Transfer.StatusQueued:
-                                        return "Waiting...";
+                                        return "Waiting…";
                                     case Transfer.StatusActive:
-                                        return "Transferring...";
+                                        return "Transferring…";
                                     case Transfer.StatusSuspended:
                                         return "Paused"
                                     case Transfer.StatusComplete:

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -1,6 +1,6 @@
 {
     "name": "ubtd.fourloop2002",
-    "description": "Enables sending and receiving files on your Ubuntu Touch device.  Thanks to Michael Zanetti <michael.zanetti@canonical.com> for the original development of this app.",
+    "description": "Enables sending and receiving files on your Ubports device.  Thanks to Michael Zanetti <michael.zanetti@canonical.com> for the original development of this app.",
     "architecture": "@CLICK_ARCH@",
     "title": "Bluetooth File Transfer",
     "hooks": {

--- a/po/ubtd.fourloop2002.pot
+++ b/po/ubtd.fourloop2002.pot
@@ -8,33 +8,33 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-24 07:57+0000\n"
+"POT-Creation-Date: 2020-01-15 16:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: /home/ianl/work/ubports/fourloop2002/ubtd/app/Main.qml:23
-msgid "Bluetooth file transfer...."
+#: /home/mardy/src/git/ubports/ubtd/app/Main.qml:23
+msgid "Bluetooth file transfer"
 msgstr ""
 
-#: /home/ianl/work/ubports/fourloop2002/ubtd/app/Main.qml:45
-msgid "Your Ubuntu Touch device is now ready to receive files via Bluetooth..."
+#: /home/mardy/src/git/ubports/ubtd/app/Main.qml:45
+msgid "Your Ubports device is now ready to receive files via Bluetooth…"
 msgstr ""
 
-#: /home/ianl/work/ubports/fourloop2002/ubtd/app/Main.qml:51
+#: /home/mardy/src/git/ubports/ubtd/app/Main.qml:51
 msgid ""
-"Send a file via Bluetooth to your Ubuntu Touch phone. It will appear in the "
-"list below."
+"Send a file via Bluetooth to your Ubports device. It will appear in the list "
+"below."
 msgstr ""
 
-#: /home/ianl/work/ubports/fourloop2002/ubtd/app/Main.qml:61
+#: /home/mardy/src/git/ubports/ubtd/app/Main.qml:61
 msgid "Transfers:"
 msgstr ""
 
-#: /home/ianl/work/ubports/fourloop2002/ubtd/app/Main.qml:202
+#: /home/mardy/src/git/ubports/ubtd/app/Main.qml:202
 msgid "Attachment"
 msgstr ""


### PR DESCRIPTION
Remove explicit references to Ubuntu by using the Ubports name instead.
Use the `…` character for dots, and remove unnecessary ones.

Update the .pot file accordingly.